### PR TITLE
chore: 0.6.0 release prep — in-graph bump workflows + housekeeping

### DIFF
--- a/.github/workflows/flathub-bump.yml
+++ b/.github/workflows/flathub-bump.yml
@@ -1,71 +1,88 @@
 # Bump the Solarxy Flathub manifest after each stable GitHub Release.
 #
-# Steps:
-#   1. Verify the FLATHUB_PAT secret is set (step-level guard — job-level
-#      `if: secrets.X != ''` is not a valid GHA expression and silently
-#      no-ops; first-step check makes the skip explicit in the log).
+# Steps (when enabled):
+#   1. Gate — proceed only if FLATHUB_PAT is set AND the tag is not a
+#      prerelease (Flathub gets stable releases only).
 #   2. Regenerate `cargo-sources.json` against the released `Cargo.lock`.
 #   3. Open a PR against `github.com/flathub/dev.koljam.solarxy` updating
-#      the manifest's `commit:` ref and replacing the cargo-sources file.
+#      the manifest's `tag:` ref and replacing the cargo-sources file.
 #
-# Skipped on prerelease tags (`rc.N`) — Flathub gets stable releases only.
+# Invocation:
+#   - `workflow_call` — called by cargo-dist's release.yml as a reusable
+#     workflow via the `post-announce-jobs` hook (see dist-workspace.toml).
+#     Runs in-graph (same workflow run), so the GITHUB_TOKEN chain
+#     restriction that kills `on: release: published` does not apply. The
+#     `plan` input carries cargo-dist's dist-manifest; the tag is read from
+#     `announcement_tag`.
+#   - `workflow_dispatch` — manual run against an existing release tag.
 name: Flathub bump
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      plan:
+        description: cargo-dist dist-manifest JSON payload.
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag (e.g. v0.6.0)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    env:
+      # `github.event_name` in a reusable workflow reflects the CALLER's
+      # event, not `workflow_call`, so mode is detected by input presence.
+      # `&&` short-circuits so fromJson only runs when inputs.plan is set.
+      TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || inputs.tag }}
+      IS_PRERELEASE: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_is_prerelease || false }}
     steps:
-      - name: Verify FLATHUB_PAT presence
-        id: secrets
+      - name: Gate — FLATHUB_PAT present and not a prerelease
+        id: gate
+        env:
+          FLATHUB_PAT: ${{ secrets.FLATHUB_PAT }}
         run: |
-          if [ -n "${{ secrets.FLATHUB_PAT }}" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::FLATHUB_PAT not set — Flathub bump will be skipped. Provision the secret to enable automatic submissions."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          proceed=true
+          if [ -z "$FLATHUB_PAT" ]; then
+            echo "::warning::FLATHUB_PAT not set — Flathub bump skipped. Provision the secret to enable automatic submissions."
+            proceed=false
           fi
-
-      - name: Resolve tag
-        if: steps.secrets.outputs.ready == 'true'
-        id: tag
-        run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          tag="${TAG#v}"
+          if [ "$IS_PRERELEASE" = "true" ] || [[ "$tag" == *-rc.* || "$tag" == *-alpha.* || "$tag" == *-beta.* ]]; then
+            echo "::notice::$TAG is a prerelease — Flathub bump skipped."
+            proceed=false
           fi
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
 
       - name: Checkout solarxy at tag
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.tag.outputs.tag }}
+          ref: ${{ env.TAG }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Python (for flatpak-cargo-generator)
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Regenerate cargo-sources.json
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           chmod +x packaging/flatpak/generate-sources.sh
           ./packaging/flatpak/generate-sources.sh
 
       - name: Checkout flathub repo
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
           repository: flathub/dev.koljam.solarxy
@@ -74,9 +91,7 @@ jobs:
           fetch-depth: 1
 
       - name: Update flathub repo
-        if: steps.secrets.outputs.ready == 'true'
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           cp packaging/flatpak/dev.koljam.solarxy.yaml flathub-target/dev.koljam.solarxy.yaml
           cp packaging/flatpak/cargo-sources.json flathub-target/cargo-sources.json
@@ -86,11 +101,10 @@ jobs:
           sed -i -E "s|tag: .*|tag: ${TAG}|" flathub-target/dev.koljam.solarxy.yaml
 
       - name: Open PR against flathub
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         working-directory: flathub-target
         env:
           GH_TOKEN: ${{ secrets.FLATHUB_PAT }}
-          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           BRANCH="bump-${TAG}"
           git config user.name "solarxy-bot"

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -7,48 +7,61 @@
 # Pushes a commit directly to the tap (no PR — the tap is a single-maintainer
 # repo). Brew users get the new version on `brew update`.
 #
-# Skipped on prerelease tags (`rc.N`).
+# Invocation:
+#   - `workflow_call` — called by cargo-dist's release.yml as a reusable
+#     workflow via the `post-announce-jobs` hook (see dist-workspace.toml).
+#     Runs in-graph, so the GITHUB_TOKEN chain restriction that kills
+#     `on: release: published` does not apply. The `plan` input carries
+#     cargo-dist's dist-manifest; the tag is read from `announcement_tag`.
+#   - `workflow_dispatch` — manual run against an existing release tag.
 name: Homebrew bump
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      plan:
+        description: cargo-dist dist-manifest JSON payload.
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag (e.g. v0.6.0)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    env:
+      # `github.event_name` in a reusable workflow reflects the CALLER's
+      # event, not `workflow_call`, so mode is detected by input presence.
+      # `&&` short-circuits so fromJson only runs when inputs.plan is set.
+      TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || inputs.tag }}
+      IS_PRERELEASE: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_is_prerelease || false }}
     steps:
-      - name: Verify HOMEBREW_TAP_PAT presence
-        id: secrets
+      - name: Gate — HOMEBREW_TAP_PAT present and not a prerelease
+        id: gate
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
         run: |
-          if [ -n "${{ secrets.HOMEBREW_TAP_PAT }}" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::HOMEBREW_TAP_PAT not set — Homebrew bump will be skipped. Provision the secret to enable automatic tap updates."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          proceed=true
+          if [ -z "$HOMEBREW_TAP_PAT" ]; then
+            echo "::warning::HOMEBREW_TAP_PAT not set — Homebrew bump skipped. Provision the secret to enable automatic tap updates."
+            proceed=false
           fi
-
-      - name: Resolve tag and version
-        if: steps.secrets.outputs.ready == 'true'
-        id: tag
-        run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
+          tag="${TAG#v}"
+          if [ "$IS_PRERELEASE" = "true" ] || [[ "$tag" == *-rc.* || "$tag" == *-alpha.* || "$tag" == *-beta.* ]]; then
+            echo "::notice::$TAG is a prerelease — Homebrew bump skipped."
+            proceed=false
           fi
-          VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tap
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
           repository: koljam/homebrew-solarxy
@@ -57,11 +70,10 @@ jobs:
           fetch-depth: 1
 
       - name: Compute artifact SHA-256 sums
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         id: sha
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
         run: |
+          set -euo pipefail
           # GUI cask: macOS arm64 DMG
           DMG_URL="https://github.com/marko-koljancic/solarxy/releases/download/${TAG}/solarxy-aarch64-apple-darwin.dmg"
           # CLI formula: source tarball
@@ -72,12 +84,13 @@ jobs:
           echo "src_sha=$SRC_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Update cask + formula
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         env:
-          VERSION: ${{ steps.tag.outputs.version }}
           DMG_SHA: ${{ steps.sha.outputs.dmg_sha }}
           SRC_SHA: ${{ steps.sha.outputs.src_sha }}
         run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
           # Cask — update version + sha256
           sed -i -E "s|^( *version )\".*\"|\1\"${VERSION}\"|" tap/Casks/solarxy.rb
           sed -i -E "s|^( *sha256 )\".*\"|\1\"${DMG_SHA}\"|" tap/Casks/solarxy.rb
@@ -86,10 +99,8 @@ jobs:
           sed -i -E "s|^( *sha256 )\".*\"|\1\"${SRC_SHA}\"|" tap/Formula/solarxy-cli.rb
 
       - name: Commit and push
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         working-directory: tap
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           git config user.name "solarxy-bot"
           git config user.email "noreply@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,3 +313,30 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-flathub-bump:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/flathub-bump.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
+  custom-homebrew-bump:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/homebrew-bump.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
+  custom-winget-release:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/winget-release.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -8,65 +8,76 @@
 # Microsoft moderation review typically takes 3-7 days. Once merged, users
 # install with `winget install Koljam.Solarxy`.
 #
-# Skipped on prerelease tags (`rc.N`).
+# Invocation:
+#   - `workflow_call` — called by cargo-dist's release.yml as a reusable
+#     workflow via the `post-announce-jobs` hook (see dist-workspace.toml).
+#     Runs in-graph, so the GITHUB_TOKEN chain restriction that kills
+#     `on: release: published` does not apply. The `plan` input carries
+#     cargo-dist's dist-manifest; the tag is read from `announcement_tag`.
+#   - `workflow_dispatch` — manual run against an existing release tag.
 name: Winget release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      plan:
+        description: cargo-dist dist-manifest JSON payload.
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag (e.g. v0.6.0)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   submit:
     runs-on: windows-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    env:
+      # `github.event_name` in a reusable workflow reflects the CALLER's
+      # event, not `workflow_call`, so mode is detected by input presence.
+      # `&&` short-circuits so fromJson only runs when inputs.plan is set.
+      TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag || inputs.tag }}
+      IS_PRERELEASE: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_is_prerelease || false }}
     steps:
-      - name: Verify WINGET_RELEASE_PAT presence
-        id: secrets
+      - name: Gate — WINGET_RELEASE_PAT present and not a prerelease
+        id: gate
         shell: bash
+        env:
+          WINGET_RELEASE_PAT: ${{ secrets.WINGET_RELEASE_PAT }}
         run: |
-          if [ -n "${{ secrets.WINGET_RELEASE_PAT }}" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::WINGET_RELEASE_PAT not set — winget submission will be skipped. Provision a fork PAT to enable automatic submissions."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          proceed=true
+          if [ -z "$WINGET_RELEASE_PAT" ]; then
+            echo "::warning::WINGET_RELEASE_PAT not set — winget submission skipped. Provision a fork PAT to enable automatic submissions."
+            proceed=false
           fi
-
-      - name: Resolve tag and version
-        if: steps.secrets.outputs.ready == 'true'
-        id: tag
-        shell: bash
-        run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
+          tag="${TAG#v}"
+          if [ "$IS_PRERELEASE" = "true" ] || [[ "$tag" == *-rc.* || "$tag" == *-alpha.* || "$tag" == *-beta.* ]]; then
+            echo "::notice::$TAG is a prerelease — winget submission skipped."
+            proceed=false
           fi
-          VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
 
       - name: Install wingetcreate
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
       - name: Submit to winget-pkgs
-        if: steps.secrets.outputs.ready == 'true'
+        if: steps.gate.outputs.proceed == 'true'
         shell: pwsh
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
-          VERSION: ${{ steps.tag.outputs.version }}
           WINGET_PAT: ${{ secrets.WINGET_RELEASE_PAT }}
         run: |
+          $version = $env:TAG -replace '^v', ''
           $msiUrl = "https://github.com/marko-koljancic/solarxy/releases/download/$env:TAG/solarxy-x86_64-pc-windows-msvc.msi"
           ./wingetcreate.exe update Koljam.Solarxy `
-            --version $env:VERSION `
+            --version $version `
             --urls $msiUrl `
             --submit `
             --token $env:WINGET_PAT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Left-click in review mode (`Shift+R`) walks a three-step ladder in `state/input/
 
 ## Performance
 
-Performance baseline + profiling notes from rc.11 are deferred to 0.6.0; measurements are filled in on maintainer hardware as hot paths are profiled. The previous `docs/perf/` skeleton was removed alongside the v0.5.0 documentation overhaul.
+Performance baseline + profiling notes from rc.11 are deferred to a later milestone; measurements are filled in on maintainer hardware as hot paths are profiled. The previous `docs/perf/` skeleton was removed alongside the v0.5.0 documentation overhaul.
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Full user documentation lives in the [Solarxy Wiki](https://github.com/marko-kol
 - **Ayu Mirage theme** -- flat dark UI with amber accent (`#FFC44C`), bundled Lilex font, custom dock styling
 - **egui sidebar** -- interactive control panel with bidirectional keyboard sync
 - **Interactive analysis** -- TUI with per-mesh and per-material breakdowns, validation checks
-- **Persistent preferences** -- configure defaults via the GUI **Edit → Preferences…** dialog (`Ctrl/⌘+,`) or tweak the TOML file directly; live changes in the viewer are saved with `Shift+S`
+- **Persistent preferences** -- configure defaults via the GUI **Edit → Preferences…** dialog (`Ctrl/⌘+,`) or tweak the TOML file directly; live viewer changes are persisted via **Edit → Save View Settings as Default**
 - **Drag-and-drop** -- drop model files or HDR/EXR environment maps directly into the viewer window
 
 ## Supported Formats

--- a/crates/solarxy-core/src/preferences.rs
+++ b/crates/solarxy-core/src/preferences.rs
@@ -509,8 +509,8 @@ cycle_enum! {
 /// split):
 /// - GUI **Edit → Preferences…** (`Ctrl/⌘+,`) — startup-only fields
 ///   (window size, MSAA), UI defaults, updater behaviour.
-/// - GUI sidebar + `Shift+S` — live per-session display / rendering /
-///   lighting settings.
+/// - GUI sidebar + **Edit → Save View Settings as Default** — live
+///   per-session display / rendering / lighting settings.
 /// - Direct TOML editing — anything; reload via the modal's
 ///   **Open config file** button.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,8 +21,20 @@ install-updater = false
 # - native-bundle: produces DMG / AppImage and uploads them to the release.
 # - ghcr-publish:  builds and pushes ghcr.io/marko-koljancic/solarxy-cli:<tags>
 #                  (skipped on prereleases).
-post-announce-jobs = ["./native-bundle", "./ghcr-publish"]
+# - flathub-bump / homebrew-bump / winget-release: submit the GUI to the
+#   downstream package channels. Each gates internally on its PAT secret
+#   being set and on the tag being a stable release (no-op otherwise).
+post-announce-jobs = [
+    "./native-bundle",
+    "./ghcr-publish",
+    "./flathub-bump",
+    "./homebrew-bump",
+    "./winget-release",
+]
 
-# wix/main.wxs is edited by hand to set the product icon from res/bundle/.
-# Tell dist not to fight us on subsequent `dist generate` runs.
+# Generated files dist must NOT overwrite on `dist generate`:
+# - msi: wix/main.wxs carries a hand-set product icon from res/bundle/.
+# - ci:  release.yml carries a hand-added `packages: write` permission so the
+#        in-graph ghcr-publish job can push to GHCR — dist only emits
+#        `contents: write`. If you ever regenerate ci, re-apply that line.
 allow-dirty = ["msi", "ci"]

--- a/scripts/build_local_dmg.sh
+++ b/scripts/build_local_dmg.sh
@@ -13,13 +13,13 @@
 #   ./bundle-out/Solarxy-<ver>-<arch>.dmg
 #
 # Usage:
-#   ./packaging/scripts/build_local_dmg.sh                 # defaults to current arch, v0.5.0
-#   V=0.5.0 TARGET=x86_64-apple-darwin ./packaging/scripts/build_local_dmg.sh
+#   ./packaging/scripts/build_local_dmg.sh                 # defaults to current arch, v0.6.0
+#   V=0.6.0 TARGET=x86_64-apple-darwin ./packaging/scripts/build_local_dmg.sh
 #
 set -euo pipefail
 
 # ---- Defaults (can be overridden via env) ---------------------------------
-: "${V:=0.5.0}"
+: "${V:=0.6.0}"
 if [ -z "${TARGET:-}" ]; then
     case "$(uname -m)" in
         arm64)  TARGET="aarch64-apple-darwin" ;;


### PR DESCRIPTION
Phase 1 of the 0.6.0 release plan. Rewires flathub-bump / homebrew-bump / winget-release as cargo-dist post-announce-jobs (they never fired on GITHUB_TOKEN-created releases), restores release.yml's packages: write, and pre-tag housekeeping. Validated via workflow_dispatch against v0.6.0-rc.3.