### PR TITLE
fix: bootstrap Homebrew + winget distribution channels

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
-          repository: koljam/homebrew-solarxy
+          repository: marko-koljancic/homebrew-solarxy
           token: ${{ secrets.HOMEBREW_TAP_PAT }}
           path: tap
           fetch-depth: 1

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,9 +1,17 @@
 # Submit Solarxy (GUI) to microsoft/winget-pkgs after each stable release.
 #
-# Uses `wingetcreate` to auto-extract the ProductCode from the produced MSI
-# and submit a PR against winget-pkgs. ProductCode rotates per build (WiX
-# generates a fresh one each time `cargo dist build` runs), so it can't be
-# hard-coded in our template — wingetcreate pulls it out of the MSI metadata.
+# Flow: check out the repo at the release tag, take the hand-authored
+# manifest under `packaging/winget/manifests/k/Koljam/Solarxy/<version>/`,
+# fill its two release-time placeholders, and `wingetcreate submit` it as a
+# PR to microsoft/winget-pkgs. `submit` works for both a brand-new package
+# (the first 0.6.0 submission) and every later version — unlike `update`,
+# which requires the package to already exist on winget.
+#
+# The two placeholders filled here:
+#   {{INSTALLER_SHA256}} — SHA-256 of the produced MSI artifact.
+#   {{PRODUCT_CODE}}     — WiX ProductCode GUID, read from the MSI Property
+#                          table (it rotates per build, so it can't be
+#                          hard-coded in the manifest).
 #
 # Microsoft moderation review typically takes 3-7 days. Once merged, users
 # install with `winget install Koljam.Solarxy`.
@@ -62,22 +70,61 @@ jobs:
           fi
           echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout solarxy at tag
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Install wingetcreate
         if: steps.gate.outputs.proceed == 'true'
         shell: pwsh
-        run: |
-          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+        run: Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Submit to winget-pkgs
+      - name: Fill manifest and submit to winget-pkgs
         if: steps.gate.outputs.proceed == 'true'
         shell: pwsh
         env:
-          WINGET_PAT: ${{ secrets.WINGET_RELEASE_PAT }}
+          # wingetcreate reads the token from this env var — preferred over
+          # --token, which can leak the value into logs.
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_RELEASE_PAT }}
         run: |
+          $ErrorActionPreference = 'Stop'
           $version = $env:TAG -replace '^v', ''
+          $manifestDir = "packaging/winget/manifests/k/Koljam/Solarxy/$version"
+          if (-not (Test-Path $manifestDir)) {
+            throw "No winget manifest at $manifestDir — add the version directory before tagging."
+          }
+          $installerManifest = Join-Path $manifestDir 'Koljam.Solarxy.installer.yaml'
+
+          # Download the MSI cargo-dist produced for this release.
           $msiUrl = "https://github.com/marko-koljancic/solarxy/releases/download/$env:TAG/solarxy-x86_64-pc-windows-msvc.msi"
-          ./wingetcreate.exe update Koljam.Solarxy `
-            --version $version `
-            --urls $msiUrl `
-            --submit `
-            --token $env:WINGET_PAT
+          $msiPath = Join-Path $env:RUNNER_TEMP 'solarxy.msi'
+          Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath
+
+          # SHA-256 of the installer.
+          $sha = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash
+
+          # ProductCode — read the MSI Property table via the Windows
+          # Installer COM API (WiX rotates the ProductCode every build).
+          $msi = New-Object -ComObject WindowsInstaller.Installer
+          $db = $msi.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $null, $msi, @($msiPath, 0))
+          $view = $db.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $db, @("SELECT Value FROM Property WHERE Property = 'ProductCode'"))
+          $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null) | Out-Null
+          $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+          if ($null -eq $record) { throw "ProductCode not found in $msiPath" }
+          $productCode = $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, 1)
+          if ([string]::IsNullOrWhiteSpace($productCode)) { throw "Empty ProductCode in $msiPath" }
+
+          # Fill the manifest placeholders in place.
+          (Get-Content $installerManifest -Raw) `
+            -replace '\{\{INSTALLER_SHA256\}\}', $sha `
+            -replace '\{\{PRODUCT_CODE\}\}', $productCode `
+            | Set-Content $installerManifest -NoNewline
+          Write-Host "Filled $installerManifest — SHA256=$sha ProductCode=$productCode"
+
+          # Submit the manifest set as a PR to microsoft/winget-pkgs.
+          ./wingetcreate.exe submit $manifestDir `
+            --prtitle "Koljam.Solarxy version $version"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Version is single-sourced in `[workspace.package]` in the root `Cargo.toml`. Bum
 - `.deb` + `.rpm` were dropped in rc.7 in favour of Flathub for distro-agnostic coverage; community packagers can still build native packages from source.
 
 **Distribution channels:**
-- GUI: **Flathub** (`dev.koljam.solarxy`, manifest in `packaging/flatpak/`), **Homebrew Cask** (`koljam/solarxy/solarxy`, `packaging/homebrew/`), **winget** (`Koljam.Solarxy`, manifests in `packaging/winget/manifests/k/Koljam/Solarxy/<version>/` with `{{PRODUCT_CODE}}`/`{{INSTALLER_SHA256}}` placeholders filled by `.github/workflows/winget-release.yml` on each stable tag). Plus raw DMG / MSI / AppImage bundles from GitHub Releases.
+- GUI: **Flathub** (`dev.koljam.solarxy`, manifest in `packaging/flatpak/`), **Homebrew Cask** (`marko-koljancic/solarxy/solarxy`, `packaging/homebrew/`), **winget** (`Koljam.Solarxy`, manifests in `packaging/winget/manifests/k/Koljam/Solarxy/<version>/` with `{{PRODUCT_CODE}}`/`{{INSTALLER_SHA256}}` placeholders filled by `.github/workflows/winget-release.yml` on each stable tag). Plus raw DMG / MSI / AppImage bundles from GitHub Releases.
 - CLI: `cargo-dist` installers (shell / PowerShell + portable `.zip`), Homebrew formula (`solarxy-cli`). No MSI — winget CLI manifest (portable type) still deferred (Rust-CLI convention: ripgrep, fd, zoxide, eza, bat, delta, cargo-dist itself don't ship one either).
 - `solarxy-cli --update` detects the install source via `solarxy_core::install_source::detect()`: Homebrew → `brew upgrade solarxy-cli`, Flatpak → `flatpak update dev.koljam.solarxy`, otherwise `axoupdater` self-update.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Full user documentation lives in the [Solarxy Wiki](https://github.com/marko-kol
 
 ```bash
 # macOS — installs both binaries, clears Gatekeeper automatically
-brew install --cask koljam/solarxy/solarxy
+brew install --cask marko-koljancic/solarxy/solarxy
 
 # Linux — GUI via Flathub
 flatpak install flathub dev.koljam.solarxy

--- a/packaging/homebrew/Casks/solarxy.rb
+++ b/packaging/homebrew/Casks/solarxy.rb
@@ -1,7 +1,7 @@
-# Solarxy GUI cask. Lives in the koljam/homebrew-solarxy tap.
+# Solarxy GUI cask. Lives in the marko-koljancic/homebrew-solarxy tap.
 #
 # Usage:
-#   brew install --cask koljam/solarxy/solarxy
+#   brew install --cask marko-koljancic/solarxy/solarxy
 #
 # This cask handles the macOS Gatekeeper friction that the bare DMG
 # download cannot. The `postflight` block strips

--- a/packaging/homebrew/Formula/solarxy-cli.rb
+++ b/packaging/homebrew/Formula/solarxy-cli.rb
@@ -1,7 +1,7 @@
-# Solarxy CLI formula. Lives in the koljam/homebrew-solarxy tap.
+# Solarxy CLI formula. Lives in the marko-koljancic/homebrew-solarxy tap.
 #
 # Usage:
-#   brew install koljam/solarxy/solarxy-cli
+#   brew install marko-koljancic/solarxy/solarxy-cli
 #
 # Cross-platform: macOS arm64 + macOS x86_64 + Linux x86_64 + Linux
 # aarch64. Each variant downloads the cargo-dist-produced tarball that

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,7 +1,7 @@
 # Homebrew tap files
 
 These two files belong in a separate tap repo —
-[`koljam/homebrew-solarxy`](https://github.com/koljam/homebrew-solarxy) — not this
+[`marko-koljancic/homebrew-solarxy`](https://github.com/marko-koljancic/homebrew-solarxy) — not this
 repo. They live here as the source of truth so changes to the tap go
 through the same review process as the rest of the project, and the
 `homebrew-bump.yml` workflow copies them into the tap repo on release.
@@ -18,11 +18,11 @@ through the same review process as the rest of the project, and the
 
 ## One-time tap setup
 
-1. Create a public GitHub repo `koljam/homebrew-solarxy` (the
+1. Create a public GitHub repo `marko-koljancic/homebrew-solarxy` (the
    `homebrew-` prefix is required for `brew tap` to find it).
 2. Copy the contents of this directory into the root of that repo:
    ```bash
-   git clone git@github.com:koljam/homebrew-solarxy.git
+   git clone git@github.com:marko-koljancic/homebrew-solarxy.git
    cd homebrew-solarxy
    cp -r ../solarxy/packaging/homebrew/Casks .
    cp -r ../solarxy/packaging/homebrew/Formula .
@@ -30,14 +30,14 @@ through the same review process as the rest of the project, and the
    git commit -m "initial Solarxy tap"
    git push
    ```
-3. Verify with `brew tap koljam/solarxy && brew search solarxy`.
+3. Verify with `brew tap marko-koljancic/solarxy && brew search solarxy`.
 
 ## Per-release maintenance
 
 `.github/workflows/homebrew-bump.yml` runs on every GitHub release:
 1. Downloads the new release artifacts and computes their SHA256.
 2. Patches `version` and `sha256` in both files.
-3. Pushes a commit to `koljam/homebrew-solarxy` (no PR — single-author
+3. Pushes a commit to `marko-koljancic/homebrew-solarxy` (no PR — single-author
    tap, direct push is fine).
 
 ## Manual update


### PR DESCRIPTION
Repoints the Homebrew tap to marko-koljancic (the koljam GitHub handle is someone else's), and rewrites winget-release.yml to self-publish the
  first-ever winget submission via wingetcreate submit.