### PR TITLE
fix: Homebrew cask installs the GUI only

### DIFF
--- a/packaging/homebrew/Casks/solarxy.rb
+++ b/packaging/homebrew/Casks/solarxy.rb
@@ -32,7 +32,6 @@ cask "solarxy" do
   homepage "https://github.com/marko-koljancic/solarxy"
 
   app "Solarxy.app"
-  binary "#{appdir}/Solarxy.app/Contents/MacOS/solarxy-cli"
 
   postflight do
     require "fileutils"


### PR DESCRIPTION
Drops the cask's binary stanza so the cask (GUI) and the solarxy-cli formula stop colliding on /opt/homebrew/bin/solarxy-cli.