### PR TITLE
fix(schema): drop non-standard numeric formats from the JSON Schema

### DIFF
--- a/crates/solarxy-core/examples/gen_schemas.rs
+++ b/crates/solarxy-core/examples/gen_schemas.rs
@@ -6,15 +6,13 @@
 //!     > schemas/solarxy-config.v1.json
 //! ```
 //!
-//! The companion test `tests/schema_drift.rs` asserts the file on disk is
-//! byte-equal to the schema this example would emit — so CI catches any
-//! schema change that wasn't regenerated.
+//! The companion test `tests/schema_drift.rs` asserts the checked-in file
+//! matches the schema this example emits — so CI catches any schema change
+//! that wasn't regenerated. Both go through `project_config::schema_json`.
 
 #[cfg(feature = "schemars-gen")]
 fn main() {
-    use solarxy_core::project_config::ProjectConfig;
-    let schema = schemars::schema_for!(ProjectConfig);
-    let json = serde_json::to_string_pretty(&schema).expect("serialize schema");
+    let json = solarxy_core::project_config::schema_json().expect("generate JSON schema");
     println!("{json}");
 }
 

--- a/crates/solarxy-core/src/project_config.rs
+++ b/crates/solarxy-core/src/project_config.rs
@@ -65,6 +65,57 @@ fn default_format_version() -> u32 {
     FORMAT_VERSION_CURRENT
 }
 
+/// Generates the [`ProjectConfig`] JSON Schema as a pretty-printed string.
+///
+/// `schemars` annotates numeric fields with non-standard `format` values
+/// (`uint32`, `float`, and similar) that strict JSON Schema validators
+/// reject as unknown formats. Those annotations carry no validation meaning
+/// — `type` plus `minimum` already constrain the values — so they are
+/// removed here. Shared by the `gen_schemas` example and the `schema_drift`
+/// test so both emit identical output.
+///
+/// # Errors
+///
+/// Returns the underlying `serde_json` error if the generated schema fails
+/// to round-trip through a [`serde_json::Value`] (not expected in practice).
+#[cfg(feature = "schemars-gen")]
+pub fn schema_json() -> Result<String, serde_json::Error> {
+    let schema = schemars::schema_for!(ProjectConfig);
+    let mut value = serde_json::to_value(&schema)?;
+    strip_nonstandard_formats(&mut value);
+    serde_json::to_string_pretty(&value)
+}
+
+/// Recursively removes the non-standard numeric `format` annotations
+/// `schemars` emits for Rust integer and float types — see [`schema_json`].
+#[cfg(feature = "schemars-gen")]
+fn strip_nonstandard_formats(value: &mut serde_json::Value) {
+    const NUMERIC_FORMATS: &[&str] = &[
+        "int8", "int16", "int32", "int64", "int128", "isize", "int", "uint8", "uint16", "uint32",
+        "uint64", "uint128", "usize", "uint", "float", "double",
+    ];
+    match value {
+        serde_json::Value::Object(map) => {
+            let drop_format = matches!(
+                map.get("format"),
+                Some(serde_json::Value::String(f)) if NUMERIC_FORMATS.contains(&f.as_str())
+            );
+            if drop_format {
+                map.remove("format");
+            }
+            for child in map.values_mut() {
+                strip_nonstandard_formats(child);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                strip_nonstandard_formats(item);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars-gen", derive(schemars::JsonSchema))]

--- a/crates/solarxy-core/tests/schema_drift.rs
+++ b/crates/solarxy-core/tests/schema_drift.rs
@@ -12,7 +12,7 @@
 
 use std::path::PathBuf;
 
-use solarxy_core::project_config::ProjectConfig;
+use solarxy_core::project_config::schema_json;
 
 fn workspace_root() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -26,8 +26,7 @@ fn workspace_root() -> PathBuf {
 
 #[test]
 fn solarxy_config_schema_matches_disk() {
-    let schema = schemars::schema_for!(ProjectConfig);
-    let generated_str = serde_json::to_string_pretty(&schema).expect("serialize schema");
+    let generated_str = schema_json().expect("generate JSON schema");
     let path = workspace_root().join("schemas/solarxy-config.v1.json");
     let on_disk =
         std::fs::read_to_string(&path).expect("schemas/solarxy-config.v1.json must exist");

--- a/schemas/solarxy-config.v1.json
+++ b/schemas/solarxy-config.v1.json
@@ -1,124 +1,44 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ProjectConfig",
-  "type": "object",
-  "properties": {
-    "budgets": {
-      "default": {
-        "default": 30000,
-        "environment": 50000,
-        "hero": 100000,
-        "prop": 20000
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Budgets"
-        }
-      ]
-    },
-    "filenames": {
-      "default": {
-        "rules": []
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/FilenameClassifier"
-        }
-      ]
-    },
-    "format_version": {
-      "default": 1,
-      "type": "integer",
-      "format": "uint32",
-      "minimum": 0.0
-    },
-    "review": {
-      "default": {
-        "sidecar_dir": null
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ReviewSettings"
-        }
-      ]
-    },
-    "thresholds": {
-      "default": {
-        "flipped_normal_dot": -0.5,
-        "triangle_budget_tolerance_percent": 20.0
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ValidationThresholds"
-        }
-      ]
-    },
-    "validation": {
-      "default": {
-        "allow_open_mesh": false,
-        "degenerate_triangles": true,
-        "flipped_normals": true,
-        "index_buffer": true,
-        "material_refs": true,
-        "non_manifold_edges": true,
-        "normal_mismatch": true,
-        "triangle_budget": true,
-        "uv_presence": true
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ValidationConfig"
-        }
-      ]
-    }
-  },
   "additionalProperties": false,
   "definitions": {
     "AssetCategory": {
-      "type": "string",
       "enum": [
         "hero",
         "prop",
         "environment",
         "default"
-      ]
+      ],
+      "type": "string"
     },
     "Budgets": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "default": {
           "default": 30000,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0.0,
+          "type": "integer"
         },
         "environment": {
           "default": 50000,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0.0,
+          "type": "integer"
         },
         "hero": {
           "default": 100000,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0.0,
+          "type": "integer"
         },
         "prop": {
           "default": 20000,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "ClassifierRule": {
-      "type": "object",
-      "required": [
-        "category",
-        "pattern"
-      ],
+      "additionalProperties": false,
       "properties": {
         "category": {
           "$ref": "#/definitions/AssetCategory"
@@ -127,38 +47,42 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "required": [
+        "category",
+        "pattern"
+      ],
+      "type": "object"
     },
     "FilenameClassifier": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "rules": {
           "default": [],
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ClassifierRule"
-          }
+          },
+          "type": "array"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "ReviewSettings": {
+      "additionalProperties": false,
       "description": "Project-level review-system settings. User-level prefs (display name for the `author` field, panel open default) live in [`crate::preferences::ReviewPrefs`].",
-      "type": "object",
       "properties": {
         "sidecar_dir": {
-          "description": "Override location of the `.solarxy-review.json` sidecar. `None` (default) ⇒ sibling to the model file. Relative paths are resolved against the model's parent directory (so `\".solarxy\"` produces `<model_dir>/.solarxy/<stem>.solarxy-review.json`). Absolute paths are used as-is.",
           "default": null,
+          "description": "Override location of the `.solarxy-review.json` sidecar. `None` (default) ⇒ sibling to the model file. Relative paths are resolved against the model's parent directory (so `\".solarxy\"` produces `<model_dir>/.solarxy/<stem>.solarxy-review.json`). Absolute paths are used as-is.",
           "type": [
             "string",
             "null"
           ]
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "ValidationConfig": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "allow_open_mesh": {
           "default": false,
@@ -197,23 +121,92 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "ValidationThresholds": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "flipped_normal_dot": {
           "default": -0.5,
-          "type": "number",
-          "format": "float"
+          "type": "number"
         },
         "triangle_budget_tolerance_percent": {
           "default": 20.0,
-          "type": "number",
-          "format": "float"
+          "type": "number"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     }
-  }
+  },
+  "properties": {
+    "budgets": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Budgets"
+        }
+      ],
+      "default": {
+        "default": 30000,
+        "environment": 50000,
+        "hero": 100000,
+        "prop": 20000
+      }
+    },
+    "filenames": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/FilenameClassifier"
+        }
+      ],
+      "default": {
+        "rules": []
+      }
+    },
+    "format_version": {
+      "default": 1,
+      "minimum": 0.0,
+      "type": "integer"
+    },
+    "review": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReviewSettings"
+        }
+      ],
+      "default": {
+        "sidecar_dir": null
+      }
+    },
+    "thresholds": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValidationThresholds"
+        }
+      ],
+      "default": {
+        "flipped_normal_dot": -0.5,
+        "triangle_budget_tolerance_percent": 20.0
+      }
+    },
+    "validation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValidationConfig"
+        }
+      ],
+      "default": {
+        "allow_open_mesh": false,
+        "degenerate_triangles": true,
+        "flipped_normals": true,
+        "index_buffer": true,
+        "material_refs": true,
+        "non_manifold_edges": true,
+        "normal_mismatch": true,
+        "triangle_budget": true,
+        "uv_presence": true
+      }
+    }
+  },
+  "title": "ProjectConfig",
+  "type": "object"
 }


### PR DESCRIPTION
schemars emits non-standard format: uint32/float that strict validators reject. A shared schema_json() strips them; the gen_schemas example and
  schema_drift test both route through it; the schema is regenerated.